### PR TITLE
Add: Surface Node List

### DIFF
--- a/AntiquerChain/Network/MessageType.cs
+++ b/AntiquerChain/Network/MessageType.cs
@@ -4,13 +4,33 @@ using System.Text;
 
 namespace AntiquerChain.Network
 {
-    public enum MessageType
+    public enum MessageType : byte
     {
-        HandShake,
-        Addr,
-        Ping,
-        Inventory,
-        Notice,
-        SurfaceHandShake
+        #region Server
+        
+        HandShake = 0x00,
+        Addr = 0x01,
+        
+        #endregion
+
+        #region Surface
+        
+        SurfaceHandShake = 0x10,
+
+        #endregion
+
+        #region Transactions
+
+        Inventory = 0x20,
+
+        #endregion
+
+        #region Others
+
+        Ping = 0x30,
+        Notice = 0x31,
+
+        #endregion
+
     }
 }

--- a/AntiquerChain/Network/NetworkManager.cs
+++ b/AntiquerChain/Network/NetworkManager.cs
@@ -12,7 +12,7 @@ using static AntiquerChain.Network.Util.Messenger;
 
 namespace AntiquerChain.Network
 {
-    public class NetworkManager
+    public class NetworkManager : IDisposable
     {
         private Server _server;
         private ILogger _logger = Logging.Create<NetworkManager>();
@@ -28,13 +28,7 @@ namespace AntiquerChain.Network
             _server.MessageReceived += MessageHandle;
             _timer = new Timer(async _ => await AllConnectionCheckAsync(), null,
                 TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
-            token.Register(_timer.Dispose);
-            token.Register(_server.Dispose);
-            token.Register(() =>
-            {
-                ConnectSurfaces?.Clear();
-                ConnectServers?.Clear();
-            });
+            token.Register(Dispose);
         }
 
         public async Task StartServerAsync() => await (_server?.StartAsync() ?? Task.CompletedTask);
@@ -202,6 +196,14 @@ namespace AntiquerChain.Network
             var listAstr = listA.DistinctByAddress().Select(i => $"{i.Address}").OrderBy(s => s).ToArray();
             var listBstr = listB.DistinctByAddress().Select(i => $"{i.Address}").OrderBy(s => s).ToArray();
             return listBstr.SequenceEqual(listAstr);
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+            _server.Dispose();
+            ConnectSurfaces?.Clear();
+            ConnectServers?.Clear();
         }
     }
 }

--- a/AntiquerChain/Network/Server.cs
+++ b/AntiquerChain/Network/Server.cs
@@ -21,7 +21,6 @@ namespace AntiquerChain.Network
 
         public event Func<Message, IPEndPoint, Task> MessageReceived;
         public event Func<IPEndPoint, MessageType, Task> NewConnection;
-        public List<IPEndPoint> ConnectingEndPoints { get; set; } = new List<IPEndPoint>();
 
         public Server( CancellationTokenSource tokenSource)
         {
@@ -71,7 +70,6 @@ namespace AntiquerChain.Network
         public void Dispose()
         {
             _logger.LogInformation("Server: Stop listening...");
-            ConnectingEndPoints?.Clear();
             if (TokenSource is null) return;
             TokenSource.Cancel();
             TokenSource.Dispose();


### PR DESCRIPTION
Surface ノードを管理出来るようにしました。
既存のシステムを改良する必要があったため、以下の大幅な変更を加えました。
* AddEndPointを削除、NewConnectionイベントのパラメーターを変更。
    * NewConnection Handler で MessageType によって登録先のリストを変更するように。
* Server Node リストを Server class から NetworkManager class へ移動。
    * NetworkManager に Dispose メソッドを追加。Dispose() でサーバー停止処理等を行うように変更。
* RemoveEndPoint で「エンドポイントを削除するリスト」を選択できるように変更
* 将来的な実装に備えて MessageType に byte を適用。